### PR TITLE
Fix session token creation endpoint URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ const createSessionToken = (expirationDate: DateFormat): Effect.Effect<string, T
   Effect.tryPromise({
     try: async () => {
       const { consumerToken, employeeToken } = config;
-      const response = await axios.put(`${baseUrl}/token/session/:create`, null, {
+      const response = await axios.put(`${baseUrl}/token/session/create`, null, {
         params: {
           consumerToken,
           employeeToken,


### PR DESCRIPTION
### TL;DR
Fixed incorrect session token creation endpoint URL by removing colon prefix

### What changed?
Updated the session token creation endpoint URL from `/token/session/:create` to `/token/session/create`

### How to test?
1. Attempt to create a new session token
2. Verify the request successfully reaches the correct endpoint
3. Confirm a valid session token is returned

### Why make this change?
The colon prefix in the URL path was causing requests to fail as the API endpoint doesn't expect a URL parameter. This fix ensures requests are properly routed to the correct endpoint.