### PR TITLE
Fix session token creation URL format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,8 @@ const createSessionToken = (expirationDate: DateFormat): Effect.Effect<string, T
   Effect.tryPromise({
     try: async () => {
       const { consumerToken, employeeToken } = config;
-      const response = await axios.put(`${baseUrl}/token/session/create`, null, {
+      const url = new URL(`${baseUrl}/token/session/:create`);
+      const response = await axios.put(url.toString(), null, {
         params: {
           consumerToken,
           employeeToken,


### PR DESCRIPTION
### TL;DR

Updated the session token creation endpoint URL format to use a URL object.

### What changed?

Modified the `createSessionToken` function to construct the API endpoint URL using the JavaScript `URL` class instead of string concatenation. The endpoint path was also updated from `/token/session/create` to `/token/session/:create`.

### Rationale
The path is using `:create` which needs to URL escaped